### PR TITLE
修复了一个返回值为空可能导致的崩溃bug

### DIFF
--- a/entry/src/main/ets/pages/NavDest/ThreadPostList.ets
+++ b/entry/src/main/ets/pages/NavDest/ThreadPostList.ets
@@ -748,8 +748,11 @@ struct SinglePostPage {
   visiblePageChanged() {
     if (this.scroller && typeof this.scroller.getItemIndex == 'function' &&
       typeof this.scroller.currentOffset == 'function') {
-      const index = this.scroller.getItemIndex(0, this.scroller.currentOffset().yOffset)
-      this.recordViewHistory(index)
+      const offset = this.scroller.currentOffset()
+      if (offset) {
+        const index = this.scroller.getItemIndex(0, offset.yOffset)
+        this.recordViewHistory(index)
+      }
     }
   }
 


### PR DESCRIPTION
崩溃原因：visiblePageChanged（ThreadPostList.ets:748）中，this.scroller.currentOffset() 在 Swiper 切页触发状态变更时，Scroller尚未挂载或已被回收，返回 undefined，直接访问 .yOffset 导致TypeError。

修复：先取 currentOffset() 返回值到变量，判空后再访问 .yOffset。